### PR TITLE
Fix electron-builder build failures in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "attendant-scheduler",
+  "description": "Attendant Scheduler for Jehovah's Witnesses Circuit Assemblies and Regional Conventions",
+  "author": "leohnaran",
   "private": true,
   "version": "3.6.3",
   "type": "module",
@@ -38,6 +40,9 @@
     },
     "win": {
       "target": "nsis"
+    },
+    "linux": {
+      "target": "AppImage"
     }
   },
   "dependencies": {


### PR DESCRIPTION
Fixing failing GitHub Actions workflow for the Electron build. Specifically targeting the `snapcraft is not installed` error on Linux by explicitly generating only an AppImage, and supplying the missing `author` and `description` root fields in `package.json` that caused warnings and potential aborts on the Windows build.

---
*PR created automatically by Jules for task [11229876319758893756](https://jules.google.com/task/11229876319758893756) started by @leohnaran*