### PR TITLE
fix: resolve Vite build failure and duplicate TypeScript exports

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/utils/excelExport.ts
+++ b/src/utils/excelExport.ts
@@ -19,63 +19,6 @@ interface ExportLookup {
   personAuditorium: Map<number, string>;
 }
 
-export async function exportToExcel({
-  personnel,
-  assignments,
-  areas,
-  positions,
-  shifts,
-}: Omit<ExportToExcelProps, 'language'>) {
-  const workbook = new ExcelJS.Workbook();
-  const personnelMap = new Map<number, Person>(personnel.map((p) => [p.id, p]));
-  const positionsMap = new Map<string, Position>(positions.map((p) => [p.id, p]));
-
-  const lookup: ExportLookup = {
-    personnelMap,
-    positionsMap,
-    personAssignments: new Map(),
-    personAuditorium: new Map()
-  };
-
-  // Pre-compute assignment indices for O(1) lookups
-  Object.keys(assignments).forEach((k) => {
-    const pId = getAssignId(assignments[k]);
-    if (!pId) return;
-
-    if (k.includes('_')) {
-      const parts = k.split('_');
-      const shiftId = parts.pop()!;
-      const posId = parts.join('_');
-      if (!lookup.personAssignments.has(pId)) {
-        lookup.personAssignments.set(pId, new Map<string, string>());
-      }
-      lookup.personAssignments.get(pId)!.set(shiftId, posId);
-    } else {
-      lookup.personAuditorium.set(pId, k);
-    }
-  });
-
-  // --- SHEET 1: FULL SCHEDULE (Original Request) ---
-  const scheduleSheet = workbook.addWorksheet('Full Schedule');
-  setupScheduleSheet(scheduleSheet, areas, positions, shifts, assignments, personnelMap);
-
-  // --- SHEET 2: ASSIGNMENTS BY POSITION (New Request) ---
-  const posSheet = workbook.addWorksheet('Assignments by Position');
-  setupByPositionSheet(posSheet, positions, shifts, assignments, personnelMap);
-
-  // --- SHEET 3: ASSIGNMENTS BY VOLUNTEER (New Request) ---
-  const volSheet = workbook.addWorksheet('Assignments by Volunteer');
-  setupByVolunteerSheet(volSheet, personnel, lookup);
-
-  // --- SHEET 4: KEY MAN REPORTS ---
-  const kmSheet = workbook.addWorksheet('Key Man Reports');
-  setupKeyManReportsSheet(kmSheet, personnel, positions, shifts, assignments, areas, lookup);
-
-  // Write and Save
-  const buffer = await workbook.xlsx.writeBuffer();
-  const blob = new Blob([buffer as BlobPart], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
-  saveAs(blob, `Attendant_Schedule_${new Date().toISOString().split('T')[0]}.xlsx`);
-}
 
 function setupScheduleSheet(
   sheet: any, 
@@ -223,7 +166,7 @@ function setupByVolunteerSheetFixed(
 }
 
 // Updating the main call to use the fixed one
-export async function exportToExcelFinal({
+export async function exportToExcel({
   personnel,
   assignments,
   areas,
@@ -350,5 +293,3 @@ function setupKeyManReportsSheet(
   });
 }
 
-// Ensure compatible export
-export const exportToExcel = exportToExcelFinal;


### PR DESCRIPTION
🎯 **What**
This PR fixes the Vite build process which was failing due to two distinct issues:
1. `index.html` was still pointing to `/src/main.jsx`, which caused a Rollup resolution error because the file had been migrated to `/src/main.tsx`.
2. `src/utils/excelExport.ts` contained multiple, conflicting declarations and exports for `exportToExcel`.

💡 **Why**
During the recent TypeScript migration, the application entry point was renamed, but `index.html` was not updated. Additionally, iterative changes in `excelExport.ts` left duplicate functions and export statements which tripped up `esbuild` during the minification/bundling phase.

✅ **Verification**
- Checked `index.html` to confirm correct reference to `/src/main.tsx`.
- Removed the old/redundant `exportToExcel` function in `src/utils/excelExport.ts` and successfully renamed the working `exportToExcelFinal` version to `exportToExcel`.
- Ran `npm run build` locally, and the build succeeds in ~13 seconds.
- Ran `npx vitest run` successfully.

✨ **Result**
The GitHub actions workflow will no longer fail during the Vite production build stage.

---
*PR created automatically by Jules for task [13245924144957962460](https://jules.google.com/task/13245924144957962460) started by @leohnaran*