### PR TITLE
fix: align roster table columns by using flexbox layout

### DIFF
--- a/src/components/roster/PersonRow.tsx
+++ b/src/components/roster/PersonRow.tsx
@@ -71,14 +71,14 @@ export default function PersonRow({
     <tr
       ref={setNodeRef}
       style={style}
-      className={`draggable-row transition-all duration-200 ${isEditing
+      className={`draggable-row transition-all duration-200 flex w-full items-center ${isEditing
           ? 'bg-yellow-50/50 dark:bg-yellow-900/20'
           : isKeyMan
             ? 'bg-blue-50/20 dark:bg-blue-900/10 hover:bg-blue-50/40'
             : 'hover:bg-gray-50/80 bg-white dark:bg-slate-800 dark:hover:bg-slate-700/50'
         }`}
     >
-      <td className="px-6 py-3 font-medium text-gray-700 dark:text-gray-200">
+      <td className="px-6 py-3 font-medium text-gray-700 dark:text-gray-200 w-[30%] box-border">
         {isEditing ? (
           <div className="flex flex-col gap-1">
             <input
@@ -209,7 +209,7 @@ export default function PersonRow({
           </div>
         )}
       </td>
-      <td className="px-6 py-3">
+      <td className="px-6 py-3 w-[15%] box-border">
         {isEditing ? (
           <select
             value={formData.role}
@@ -239,7 +239,7 @@ export default function PersonRow({
           </span>
         )}
       </td>
-      <td className="px-6 py-3">
+      <td className="px-6 py-3 flex-1 box-border">
         {isEditing ? (
           <div>
             <div className="flex flex-wrap gap-2 max-w-[200px] mb-2">
@@ -360,7 +360,7 @@ export default function PersonRow({
           </div>
         )}
       </td>
-      <td className="px-6 py-3 text-center">
+      <td className="px-6 py-3 text-center w-32 box-border shrink-0">
         {isEditing ? (
           <div className="flex justify-center gap-2">
             <button

--- a/src/components/roster/RosterTable.tsx
+++ b/src/components/roster/RosterTable.tsx
@@ -77,23 +77,23 @@ function DroppableGroup({ group, language, rowProps }: DroppableGroupProps) {
         ref={parentRef}
         className="overflow-x-auto overflow-y-auto max-h-[400px]"
       >
-        <table className="w-full text-sm text-left">
-          <thead className="sticky top-0 z-10 bg-white dark:bg-slate-800 shadow-sm border-b border-gray-100 dark:border-slate-700">
-            <tr className="text-[10px] font-black uppercase tracking-widest text-gray-400">
-              <th className="px-6 py-3 w-1/3">
+        <table className="w-full text-sm text-left block">
+          <thead className="sticky top-0 z-10 bg-white dark:bg-slate-800 shadow-sm border-b border-gray-100 dark:border-slate-700 block w-full">
+            <tr className="text-[10px] font-black uppercase tracking-widest text-gray-400 flex w-full">
+              <th className="px-6 py-3 w-[30%]">
                 {t('roster_name', language)}
               </th>
-              <th className="px-6 py-3 w-1/6">
+              <th className="px-6 py-3 w-[15%]">
                 {t('roster_role', language)}
               </th>
-              <th className="px-6 py-3">{t('roster_perms', language)}</th>
-              <th className="px-6 py-3 w-24 text-center">
+              <th className="px-6 py-3 flex-1">{t('roster_perms', language)}</th>
+              <th className="px-6 py-3 w-32 text-center">
                 {t('grid_actions', language) || 'Actions'}
               </th>
             </tr>
           </thead>
           <tbody 
-            className="divide-y divide-gray-50 dark:divide-slate-700/50"
+            className="divide-y divide-gray-50 dark:divide-slate-700/50 block w-full"
             style={{
               height: group.members.length > 0 ? `${rowVirtualizer.getTotalSize()}px` : 'auto',
               position: 'relative'
@@ -105,10 +105,9 @@ function DroppableGroup({ group, language, rowProps }: DroppableGroupProps) {
             )}
 
             {group.members.length === 0 && !group.keyMan ? (
-              <tr>
+              <tr className="flex w-full">
                 <td
-                  colSpan={4}
-                  className="px-6 py-8 text-center text-gray-400 italic bg-gray-50/30 dark:bg-slate-800/30"
+                  className="px-6 py-8 text-center text-gray-400 italic bg-gray-50/30 dark:bg-slate-800/30 w-full"
                 >
                   {t('drop_members_hint', language) ||
                     'Drop members here to assign'}


### PR DESCRIPTION
### 🎯 What
The columns in the Roster table (Name, Role, Permissions, Actions) were not lining up correctly with the table headers (`<thead>`). The `<td>` columns were collapsed because the virtualized row implementation uses `position: absolute`, breaking the standard HTML table layout.

### 💡 Why
When `position: absolute` is applied to a `<tr>`, the browser takes it out of normal document flow, preventing the cells from sizing according to the table headers.

### 🛠️ Solution
Replaced the default HTML table layout with a Flexbox layout:
1. Updated `<table>`, `<thead>`, and `<tbody>` to use `display: block`.
2. Updated `<tr>` to use `display: flex w-full`.
3. Applied consistent, explicit widths to both the `<th>` and `<td>` elements (e.g., `w-[30%]`, `flex-1`, `w-32`) so they match perfectly even when the row is absolutely positioned.

### ✅ Verification
- Ran vitest unit tests: Passed
- Visually verified via Playwright screenshot: All columns now properly aligned under the table headers.

---
*PR created automatically by Jules for task [14194373119818584971](https://jules.google.com/task/14194373119818584971) started by @leohnaran*